### PR TITLE
fix: piston mitigation

### DIFF
--- a/data/chunk_loader/function/chunk_loader/break_piston.mcfunction
+++ b/data/chunk_loader/function/chunk_loader/break_piston.mcfunction
@@ -1,5 +1,5 @@
 execute if block ~ ~ ~ piston_head[facing=north] if block ~ ~ ~-1 #chunk_loader:chunk_loader_block run function chunk_loader:piston_break/south
-execute if block ~ ~ ~ piston_head[facing=south] if block ~ ~ ~1 #chunk_loader:chunk_loader_block run function chunk_loader:piston_break/south
+execute if block ~ ~ ~ piston_head[facing=south] if block ~ ~ ~1 #chunk_loader:chunk_loader_block run function chunk_loader:piston_break/north
 execute if block ~ ~ ~ piston_head[facing=west] if block ~-1 ~ ~ #chunk_loader:chunk_loader_block run function chunk_loader:piston_break/east
 execute if block ~ ~ ~ piston_head[facing=east] if block ~1 ~ ~ #chunk_loader:chunk_loader_block run function chunk_loader:piston_break/west
 execute if block ~ ~ ~ piston_head[facing=up] if block ~ ~1 ~ #chunk_loader:chunk_loader_block run function chunk_loader:piston_break/down

--- a/data/chunk_loader/function/piston_break/down.mcfunction
+++ b/data/chunk_loader/function/piston_break/down.mcfunction
@@ -1,2 +1,2 @@
-setblock ~ ~-1 ~ air destroy
+setblock ~ ~1 ~ air destroy
 function chunk_loader:chunk_loader/break

--- a/data/chunk_loader/function/piston_break/up.mcfunction
+++ b/data/chunk_loader/function/piston_break/up.mcfunction
@@ -1,2 +1,2 @@
-setblock ~ ~1 ~ air destroy
+setblock ~ ~-1 ~ air destroy
 function chunk_loader:chunk_loader/break


### PR DESCRIPTION
> I coded a workaround for this kind of situation to break it into an item when pushed by a piston

When you said this I was doubting myself. Testing it again, it just drops as a item. Just like you said it would.
But huh? I have grates in my inventory from earlier!

---
Turns out if the piston is facing south the wrong function was called. Meanwhile up and down had their offsets mixed up.

This PR fixes those issues. I tested all directions and they all drop the item now.

It's of course still an issue with slime/honey and pulling it back with a sticky piston, as well as if the piston is retracted instantly (e.g. putting a button on the piston block).
